### PR TITLE
Build container image with repo2docker action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build container image
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout files in repo
+      uses: actions/checkout@main
+
+    - name: update jupyter dependencies with repo2docker
+      uses: jupyterhub/repo2docker-action@master
+      with: # make sure username & password/token matches your registry
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_REGISTRY: "quay.io"
+        IMAGE_NAME: "2i2c/paleohack-2021"


### PR DESCRIPTION
Automatically builds & pushes the image with each commit. When
you want an update to the image on JupyterHub, we can pick the
commit we want from [quay.io](https://quay.io/repository/2i2c/paleohack-2021)
and use that.

Using quay.io for the registry rather than dockerhub, since dockerhub
now has aggressive image pulling rate limits.