### PR TITLE
Add nbgitpuller for pulling content into JupyterHub

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -157,5 +157,6 @@ dependencies:
     - xlrd==2.0.1
     - climlab
     - pyleoclim
+    - nbgitpuller==0.9.0
 
 


### PR DESCRIPTION
jupyterhub.github.io/nbgitpuller is to be used by participants
to pull in content for the hackathon. It needs to be installed
in the image for it to work.